### PR TITLE
Bump up to 1.4.1 and Add vim and emacs editor support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 FROM alpine:3.4
 
 ENV KUBECTL_VERSION v1.4.0
+ENV EDITOR vim
 
-RUN apk add --no-cache --update ca-certificates wget \
+RUN apk add --no-cache --update ca-certificates wget vim \
   && wget -qO /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
   && chmod +x /usr/local/bin/kubectl \
   && apk del --purge wget \
   && rm /var/cache/apk/*
+
+RUN apk add --no-cache \
+            --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+            emacs
+
 ENTRYPOINT ["/usr/local/bin/kubectl"]
 CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.4
 
-ENV KUBECTL_VERSION v1.4.0
+ENV KUBECTL_VERSION v1.4.1
 ENV EDITOR vim
 
 RUN apk add --no-cache --update ca-certificates wget vim \

--- a/README.md
+++ b/README.md
@@ -23,8 +23,13 @@ kubectl version tag:
 
 ## Usage
 
-* `docker run -it -v ~/.kube/config:/root/.kube/config koudaiii/kubectl`
-* `docker run -it -v ~/.kube/config:/root/.kube/config koudaiii/kubectl version`
+* `docker run -it -e EDITOR=vim -v ~/.kube/config:/root/.kube/config koudaiii/kubectl`
+* `docker run -it -e EDITOR=vim -v ~/.kube/config:/root/.kube/config koudaiii/kubectl version`
+
+## Support EDITOR
+
+- vim(default) or vi
+- emacs
 
 ## Contribution
 


### PR DESCRIPTION
## WHY
- kubectl v1.4.1
- editor support
