### PR TITLE
Fix emacs and Add curl and bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.4
 ENV KUBECTL_VERSION v1.4.5
 ENV EDITOR vim
 
-RUN apk add --no-cache --update ca-certificates wget vim \
+RUN apk add --no-cache --update ca-certificates wget curl bash vim \
   && wget -qO /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
   && chmod +x /usr/local/bin/kubectl \
   && apk del --purge wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache --update ca-certificates wget curl bash vim \
   && rm /var/cache/apk/*
 
 RUN apk add --no-cache \
-            --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+            --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \
             emacs
 
 ENTRYPOINT ["/usr/local/bin/kubectl"]


### PR DESCRIPTION
## WHY

```
$ docker build .
Sending build context to Docker daemon 57.34 kB
Step 1/7 : FROM alpine:3.4
 ---> baa5d63471ea
Step 2/7 : MAINTAINER Wataru MIYAGUNI <gonngo@gmail.com>
 ---> Running in f4f90bdf9fdd
 ---> 202d6bbb3d28
Removing intermediate container f4f90bdf9fdd
Step 3/7 : RUN apk add --no-cache             --repository http://dl-3.alpinelinux.org/alpine/edge/testing/             emacs
 ---> Running in 1cc2fc5da093
fetch http://dl-3.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  emacs (missing):
    required by: world[emacs]
The command '/bin/sh -c apk add --no-cache             --repository http://dl-3.alpinelinux.org/alpine/edge/testing/             emacs' returned a non-zero code: 1
```

I can't build 😿 

## WHAT

Fix docker build

```
2016/12/07 21:36:44 koudaiii@koudaiiis-MacBook-Pro:~/src/github.com/gongo/docker-emacs (master)
$ docker build .
Sending build context to Docker daemon 57.34 kB
Step 1/7 : FROM alpine:3.4
 ---> baa5d63471ea
Step 2/7 : MAINTAINER Wataru MIYAGUNI <gonngo@gmail.com>
 ---> Using cache
 ---> 202d6bbb3d28
Step 3/7 : RUN apk add --no-cache             --repository http://dl-3.alpinelinux.org/alpine/edge/community/             emacs
 ---> Running in ad5d81643d2f
fetch http://dl-3.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/13) Installing dbus-libs (1.10.8-r1)
(2/13) Installing gmp (6.1.0-r0)
(3/13) Installing nettle (3.2-r0)
(4/13) Installing libffi (3.2.1-r2)
(5/13) Installing libtasn1 (4.8-r0)
(6/13) Installing p11-kit (0.23.2-r0)
(7/13) Installing gnutls (3.4.15-r0)
(8/13) Installing ncurses-terminfo-base (6.0-r7)
(9/13) Installing ncurses-terminfo (6.0-r7)
(10/13) Installing ncurses-libs (6.0-r7)
(11/13) Installing libxml2 (2.9.4-r0)
(12/13) Installing emacs-nox (25.1-r0)
(13/13) Installing emacs (25.1-r0)
Executing busybox-1.24.2-r11.trigger
OK: 131 MiB in 24 packages
 ---> 11b51f9a3be7
Removing intermediate container ad5d81643d2f
Step 4/7 : ENV CASK /opt/cask
```

I think alpine repository changed from testing to community.

ref. https://pkgs.alpinelinux.org/packages?name=emacs&branch=&repo=&arch=&maintainer=